### PR TITLE
BUG: dim_names argument was ignored in array to tbl_cube conversion

### DIFF
--- a/R/cube.R
+++ b/R/cube.R
@@ -213,11 +213,28 @@ as.tbl_cube <- function(x, ...) UseMethod("as.tbl_cube")
 #' @param dim_names names of the dimensions. Defaults to the names of
 #'   the [dimnames()].
 #' @param met_name a string to use as the name for the measure.
+#' @description Coerce a matrix/array to a tbl_cube. The array must have row and column names
+#' and names of matrix/array dimensions must be provided if not present.
+#' @examples
+#' # array into ggplot to display with tiles
+#' m <- matrix(runif(100), 10, 10)
+#' rownames(m) <- colnames(m) <- letters[1:10]
+#' \dontrun{library(tidyverse)}
+#' \dontrun{mtib <- as_tibble(as.tbl_cube(m, met_name="brightness", dim_names=c("X", "Y")) )}
+#' \dontrun{ggplot(mtib, aes(x=X, y=Y)) + geom_tile(aes(colour=brightness, fill=brightness))}
+#'
 as.tbl_cube.array <- function(x, dim_names = names(dimnames(x)), met_name = deparse(substitute(x)),
                               ...) {
   force(met_name)
-
   dims <- dimnames(x)
+  if (is.null(dims)) {
+    stop("Array must have named rows and columns")
+  }
+  if (is.null(dim_names)) {
+    stop("Array must have named dimensions (i.e. !is.null(names(dimnames(x)))")
+  }
+
+  names(dims) <- dim_names
   dims <- lapply(dims, utils::type.convert, as.is = TRUE)
 
   mets <- setNames(list(undimname(x)), met_name)

--- a/man/as.tbl_cube.Rd
+++ b/man/as.tbl_cube.Rd
@@ -43,5 +43,15 @@ the \code{\link[=dimnames]{dimnames()}}.}
 A \code{tbl_cube}.
 }
 \description{
-Coerce an existing data structure into a \code{tbl_cube}
+Coerce a matrix/array to a tbl_cube. The array must have row and column names
+and names of matrix/array dimensions must be provided if not present.
+}
+\examples{
+# array into ggplot to display with tiles
+m <- matrix(runif(100), 10, 10)
+rownames(m) <- colnames(m) <- letters[1:10]
+\dontrun{library(tidyverse)}
+\dontrun{mtib <- as_tibble(as.tbl_cube(m, met_name="brightness", dim_names=c("X", "Y")) )}
+\dontrun{ggplot(mtib, aes(x=X, y=Y)) + geom_tile(aes(colour=brightness, fill=brightness))}
+
 }

--- a/tests/testthat/test-cube.R
+++ b/tests/testthat/test-cube.R
@@ -40,6 +40,20 @@ test_that("coercion", {
 
   expect_message(cube_tbl <- as.tbl_cube(tbl), NA)
   expect_identical(cube, cube_tbl)
+  # Can we change the names of dimensions
+  cube <- as.tbl_cube(tbl, dim_names = c("A","B"))
+  expect_identical(cube$dims, list(A = letters[1:3], B = letters[1:5]))
+  # common use case of images/correlation matrices without named
+  # dimensions
+  tbl_as_mat <- unclass(tbl)
+  # remove the dimension names
+  names(dimnames(tbl_as_mat)) <- NULL
+  expect_error(cube <- as.tbl_cube(tbl_as_mat))
+  cube <- as.tbl_cube(tbl_as_mat, dim_names=c("A", "B"))
+  expect_identical(cube$dims, list(A = letters[1:3], B = letters[1:5]))
+  # Remove all the row and column names
+  expect_error(as.tbl_cube(undimname(tbl_as_mat)))
+
 })
 
 test_that("incomplete", {


### PR DESCRIPTION
Added some error message when array dimension names are missing.
Added test cases.

It was impossible to convert an array that didn't have names(dimnames(x)) set, which is common for use cases like images and correlation matrices. The dim_names argument should have enabled the user to provide name options, but the argument was ignored and confusing error messages resulted.